### PR TITLE
Updated node-notifier to version 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "chalk": "1.1.1",
     "noble": "^1.1.0",
-    "node-notifier": "4.3.0"
+    "node-notifier": "4.3.1"
   }
 }


### PR DESCRIPTION
:rocket:

node-notifier just published version 4.3.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [9a8e305](https://github.com/mikaelbr/node-notifier/commit/9a8e3055e907d3d3db1e646525ed020fec284530): v4.3.1
- [080a423](https://github.com/mikaelbr/node-notifier/commit/080a42358cff23ee6002fbe2863b29baa859e4ce): Adds new stdin CLI options to docs
- [9b37da6](https://github.com/mikaelbr/node-notifier/commit/9b37da634625518858263f52d6bb43a0a2d77c3f): Fixes copy/paste errors in changelog

See the [full diff](https://github.com/mikaelbr/node-notifier/compare/4a7e6919721ce093b818891fa6d7bacc39e33808...9a8e3055e907d3d3db1e646525ed020fec284530).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
